### PR TITLE
reverting findOne back to find to overcome rendering issues with Chin…

### DIFF
--- a/routes/ReadFromDatabase.js
+++ b/routes/ReadFromDatabase.js
@@ -16,7 +16,7 @@ class ReadFromDatabase {
   }
 
   static oneCocktail(cocktailName, res) {
-    Cocktail.findOne(
+    Cocktail.find(
       { name: cocktailName }
     ).populate(
       { path: 'ingredients.ingredient',


### PR DESCRIPTION
…ChinReactApp

Because the results were not coming back as an array .map was not necessary in ChinChinReactApp however passing the hash through to the render was causing issues with unhandled promises which I could not resolve. Reverting to find instead of findOne would be the easiest solution in the short term.